### PR TITLE
patch number modulo input value, remove draft from version info

### DIFF
--- a/SetBuildVersionFromArtifact/fromartifact.ts
+++ b/SetBuildVersionFromArtifact/fromartifact.ts
@@ -11,7 +11,7 @@ function addBuildTag(name) {
 
 function setBuildVariable(variable, value) {
   tl.setVariable(variable, value);
-  //console.log("##vso[task.setvariable variable=%s;]%s", variable, name);
+  //console.log("##vso[task.setvariable variable=%s;]%s", variable, value);
   process.env[variable] = value;
 }
 

--- a/SetBuildVersionFromArtifact/task.json
+++ b/SetBuildVersionFromArtifact/task.json
@@ -8,8 +8,8 @@
     "author": "Matthias Dittrich",
     "version": {
         "Major": 0,
-        "Minor": 1,
-        "Patch": 9
+        "Minor": 2,
+        "Patch": 12
     },
     "instanceNameFormat": "Read version from Artifact",
     "groups": [

--- a/SetBuildVersionFromRepository/task.json
+++ b/SetBuildVersionFromRepository/task.json
@@ -8,8 +8,8 @@
     "author": "Matthias Dittrich",
     "version": {
         "Major": 0,
-        "Minor": 1,
-        "Patch": 9
+        "Minor": 2,
+        "Patch": 12
     },
     "instanceNameFormat": "Read version from $(versionTextFile)",
     "groups": [
@@ -66,6 +66,15 @@
             "defaultValue": "ProjectVersion_Patch",
             "required": false,
             "helpMarkDown": "We will save the version part in a VSTS variable as well as in an environment variable with the same name.",
+            "groupName": "variables"
+        },
+        {
+            "name": "maxPatchVersion",
+            "type": "string",
+            "label": "highest admissible pact number (otherwise wrap around)",
+            "defaultValue": "65535",
+            "required": false,
+            "helpMarkDown": "We will wrap-around the the patch part when the maximum number gets passed.",
             "groupName": "variables"
         },
         {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "matthid-semver-build-task",
     "name": "AIT SemVer Build Tools",
-    "version": "0.1.9",
+    "version": "0.2.12",
     "publisher": "matthid",
     "targets": [
         {


### PR DESCRIPTION
Wix installer projects failed. Fixes proposed:

- additional Variable in task "Set Build Version from Version file" containing highest admissible patch number. If set, patch version is wrapped around.
- In case of DRAFT builds DRAFT is not included in the environment variables.
